### PR TITLE
docs: improve PHPDoc comments with @package, @since, @var, @param, and @return tags

### DIFF
--- a/includes/class-auto-relations.php
+++ b/includes/class-auto-relations.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * Automatic Relations on Publish
- * Rule-based automation
+ * Automatic Relations on Publish.
+ *
+ * Rule-based automation for creating relationships when posts are published.
+ *
+ * @package NativeContentRelationships
+ * @since   1.0.0
  */
 
 // Exit if accessed directly
@@ -12,12 +16,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class NATICORE_Auto_Relations {
 
 	/**
-	 * Instance
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var NATICORE_Auto_Relations|null
 	 */
 	private static $instance = null;
 
 	/**
-	 * Get instance
+	 * Get singleton instance.
+	 *
+	 * @since  1.0.0
+	 * @return NATICORE_Auto_Relations
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -27,7 +37,11 @@ class NATICORE_Auto_Relations {
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
+	 *
+	 * Registers publish hooks for auto-relation creation when enabled.
+	 *
+	 * @since 1.0.0
 	 */
 	private function __construct() {
 		$settings = NATICORE_Settings::get_instance();
@@ -40,7 +54,13 @@ class NATICORE_Auto_Relations {
 	}
 
 	/**
-	 * Auto-relation to parent page
+	 * Automatically create a 'part_of' relation to the parent page on publish.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int     $post_id Post ID being published.
+	 * @param WP_Post $post    Post object being published.
+	 * @return void
 	 */
 	public function auto_relation_to_parent( $post_id, $post ) {
 		// Skip revisions and autosaves

--- a/includes/class-capabilities.php
+++ b/includes/class-capabilities.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * Capability Control
- * Manages permissions for relationship operations
+ * Capability Control.
+ *
+ * Manages permissions for relationship operations.
+ *
+ * @package NativeContentRelationships
+ * @since   1.0.0
  */
 
 // Exit if accessed directly
@@ -12,17 +16,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 class NATICORE_Capabilities {
 
 	/**
-	 * Instance
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var NATICORE_Capabilities|null
 	 */
 	private static $instance = null;
 
 	/**
-	 * Flag to prevent infinite recursion
+	 * Flag to prevent infinite recursion during capability mapping.
+	 *
+	 * @since 1.0.0
+	 * @var bool
 	 */
 	private static $mapping_in_progress = false;
 
 	/**
-	 * Get instance
+	 * Get singleton instance.
+	 *
+	 * @since  1.0.0
+	 * @return NATICORE_Capabilities
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -32,7 +45,9 @@ class NATICORE_Capabilities {
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
+	 *
+	 * @since 1.0.0
 	 */
 	private function __construct() {
 		add_filter( 'map_meta_cap', array( $this, 'map_meta_caps' ), 10, 4 );

--- a/includes/class-cleanup.php
+++ b/includes/class-cleanup.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * Safe Deletion Handling
- * Cleans up relationships when content is trashed or deleted
+ * Safe Deletion Handling.
+ *
+ * Cleans up relationships when content is trashed or deleted.
+ *
+ * @package NativeContentRelationships
+ * @since   1.0.0
  */
 
 // Exit if accessed directly
@@ -12,12 +16,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class NATICORE_Cleanup {
 
 	/**
-	 * Instance
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var NATICORE_Cleanup|null
 	 */
 	private static $instance = null;
 
 	/**
-	 * Get instance
+	 * Get singleton instance.
+	 *
+	 * @since  1.0.0
+	 * @return NATICORE_Cleanup
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -27,7 +37,11 @@ class NATICORE_Cleanup {
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
+	 *
+	 * Registers hooks for cleaning up relationships on post deletion.
+	 *
+	 * @since 1.0.0
 	 */
 	private function __construct() {
 		// Clean up on post deletion

--- a/includes/class-fluent-api.php
+++ b/includes/class-fluent-api.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * Fluent API for Content Relationships
- * Chainable, IDE-friendly API wrapper
+ * Fluent API for Content Relationships.
+ *
+ * Provides a chainable, IDE-friendly API wrapper for managing relationships.
+ *
+ * @package NativeContentRelationships
+ * @since   1.0.0
  */
 
 // Exit if accessed directly
@@ -25,32 +29,50 @@ function naticore() {
 class NATICORE_Fluent_API {
 
 	/**
-	 * Instance
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var NATICORE_Fluent_API|null
 	 */
 	private static $instance = null;
 
 	/**
-	 * Current from_id
+	 * Source post ID for the current chain.
+	 *
+	 * @since 1.0.0
+	 * @var int|null
 	 */
 	private $from_id = null;
 
 	/**
-	 * Current to_id
+	 * Target post ID for the current chain.
+	 *
+	 * @since 1.0.0
+	 * @var int|null
 	 */
 	private $to_id = null;
 
 	/**
-	 * Current type
+	 * Relationship type for the current chain.
+	 *
+	 * @since 1.0.0
+	 * @var string
 	 */
 	private $type = 'related_to';
 
 	/**
-	 * Current direction
+	 * Relationship direction for the current chain.
+	 *
+	 * @since 1.0.0
+	 * @var string|null
 	 */
 	private $direction = null;
 
 	/**
-	 * Get instance
+	 * Get singleton instance.
+	 *
+	 * @since  1.0.0
+	 * @return NATICORE_Fluent_API
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -60,7 +82,9 @@ class NATICORE_Fluent_API {
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
+	 *
+	 * @since 1.0.0
 	 */
 	private function __construct() {
 		// Reset state
@@ -68,7 +92,10 @@ class NATICORE_Fluent_API {
 	}
 
 	/**
-	 * Reset state
+	 * Reset the fluent chain state.
+	 *
+	 * @since  1.0.0
+	 * @return void
 	 */
 	private function reset() {
 		$this->from_id   = null;

--- a/includes/class-orphaned.php
+++ b/includes/class-orphaned.php
@@ -1,7 +1,11 @@
 <?php
 /**
- * Orphaned Relationships Checker
- * Weekly admin notice
+ * Orphaned Relationships Checker.
+ *
+ * Detects orphaned relationships and displays a weekly admin notice.
+ *
+ * @package NativeContentRelationships
+ * @since   1.0.0
  */
 
 // Exit if accessed directly
@@ -12,12 +16,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class NATICORE_Orphaned {
 
 	/**
-	 * Instance
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var NATICORE_Orphaned|null
 	 */
 	private static $instance = null;
 
 	/**
-	 * Get instance
+	 * Get singleton instance.
+	 *
+	 * @since  1.0.0
+	 * @return NATICORE_Orphaned
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -27,7 +37,11 @@ class NATICORE_Orphaned {
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
+	 *
+	 * Registers admin hooks for orphaned relationship detection.
+	 *
+	 * @since 1.0.0
 	 */
 	private function __construct() {
 		// Only load admin functionality in admin context
@@ -40,7 +54,10 @@ class NATICORE_Orphaned {
 	}
 
 	/**
-	 * Maybe check for orphaned relationships
+	 * Check for orphaned relationships if a week has passed since last check.
+	 *
+	 * @since  1.0.0
+	 * @return void
 	 */
 	public function maybe_check_orphaned() {
 		// Only check once per week
@@ -63,7 +80,10 @@ class NATICORE_Orphaned {
 	}
 
 	/**
-	 * Count orphaned relationships
+	 * Count orphaned relationships where from_id or to_id references a deleted post.
+	 *
+	 * @since  1.0.0
+	 * @return int Number of orphaned relationships.
 	 */
 	private function count_orphaned() {
 		global $wpdb;
@@ -81,7 +101,10 @@ class NATICORE_Orphaned {
 	}
 
 	/**
-	 * Show orphaned notice
+	 * Display an admin notice when orphaned relationships are detected.
+	 *
+	 * @since  1.0.0
+	 * @return void
 	 */
 	public function show_orphaned_notice() {
 		$count = get_option( 'naticore_orphaned_count', 0 );


### PR DESCRIPTION
## Summary

This PR addresses **#4** by improving PHPDoc documentation across multiple class files.

### Changes

Added comprehensive PHPDoc annotations to 5 files:

- **class-capabilities.php**: Added `@var` types for properties, `@since` tags, `@return` types
- **class-cleanup.php**: Added `@package`, `@since` tags, constructor description
- **class-auto-relations.php**: Added `@param`/`@return` to `auto_relation_to_parent()` method
- **class-orphaned.php**: Added `@return` types, improved method descriptions
- **class-fluent-api.php**: Added `@var` types for all class properties, `@since` tags

### Standards

All documentation follows [WordPress PHPDoc standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/):
- Sentences end with periods
- `@since` tags reference version `1.0.0`
- `@var` tags include proper type information
- `@package NativeContentRelationships` added to file headers

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of relationships when posts are deleted or trashed.
  * Orphaned relationship detection with admin notifications (weekly checks).
  * Configurable cleanup and trash handling behavior via filters.

* **Documentation**
  * Enhanced documentation across core modules for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->